### PR TITLE
Ticket 163472 org modifications

### DIFF
--- a/app/models/journal_setting.rb
+++ b/app/models/journal_setting.rb
@@ -42,4 +42,8 @@ class JournalSetting < ActiveRecord::Base
     journalized_entry_type == "unlock"
   end
   
+  def updating?
+    journalized_entry_type == "update"
+  end
+
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,3 +64,4 @@ en:
   label_1: "Yes"
   text_setting_create_organization_journal_entry: "Organization <i>%{organization}</i> has been created."
   text_setting_destroy_organization_journal_entry: "Organization <i>%{organization_name}</i> has been deleted."
+  text_setting_update_organization_journal_entry: "Organization <i>%{organization}</i> has been updated."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -63,3 +63,4 @@ fr:
   label_1: "Oui"
   text_setting_create_organization_journal_entry: "L'organisation <i>%{organization}</i> a été créée."
   text_setting_destroy_organization_journal_entry: "L'organisation <i>%{organization_name}</i> a été supprimée."
+  text_setting_update_organization_journal_entry: "L'organisation <i>%{organization}</i> a été modifiés."

--- a/init.rb
+++ b/init.rb
@@ -12,6 +12,7 @@ ActiveSupport::Reloader.to_prepare do
   if Redmine::Plugin.installed?(:redmine_organizations)
     require_dependency 'redmine_admin_activity/controllers/organizations/memberships_controller'
     require_dependency 'redmine_admin_activity/controllers/organizations_controller'
+    require_dependency 'redmine_admin_activity/models/organization'
   end
 
   require_dependency 'redmine_admin_activity/controllers/users_controller'

--- a/lib/redmine_admin_activity/controllers/organizations_controller.rb
+++ b/lib/redmine_admin_activity/controllers/organizations_controller.rb
@@ -5,6 +5,8 @@ class OrganizationsController < ApplicationController
   after_action :journalized_organizations_creation, :only => [:create]
   after_action :journalized_organizations_deletion, :only => [:destroy]
   before_action :memorize_deleted_organizations, :only => [:destroy]
+  before_action :memorize_attributes_organizations, :only => [:update]
+  after_action :journalized_organizations_update, :only => [:update]
 
   private
 
@@ -41,5 +43,26 @@ class OrganizationsController < ApplicationController
 
   def memorize_deleted_organizations
     @deleted_organizations = @organization.self_and_descendants.to_a
+  end
+
+  def memorize_attributes_organizations
+    @old_attributes = @organization.attributes
+  end
+
+  def journalized_organizations_update
+    # Build hash of previous_changes manually, After a long search, I couldn't know why the previous changes are empty when changing the parent.
+    @previous_changes = {}
+    @new_attributes = @organization.attributes
+    @new_attributes.each do |key, val|
+      @previous_changes[key] =
+          [@old_attributes[key], val] if @organization.journalized_attribute_names.include?(key) && @old_attributes[key] != val
+    end
+
+    JournalSetting.create(
+      :user_id => User.current.id,
+      :value_changes => @previous_changes,
+      :journalized => @organization,
+      :journalized_entry_type => "update",
+    )
   end
 end

--- a/lib/redmine_admin_activity/models/organization.rb
+++ b/lib/redmine_admin_activity/models/organization.rb
@@ -1,0 +1,11 @@
+require_dependency 'organization'
+
+class Organization < ActiveRecord::Base
+
+  # Returns the names of attributes that are journalized when updating the organization
+  def journalized_attribute_names
+    names = Organization.column_names - %w(id lft rgt created_at updated_at name_with_parents identifier)
+    names
+  end
+
+end

--- a/lib/redmine_admin_activity/models/user.rb
+++ b/lib/redmine_admin_activity/models/user.rb
@@ -21,7 +21,7 @@ class User < Principal
 
   # Returns the names of attributes that are journalized when updating the user
   def journalized_attribute_names
-    %w(login firstname lastname admin status organization sudoer staff beta_tester instance_manager issue_display_mode trusted_api_user mails)
+    %w(login firstname lastname admin status organization_id sudoer staff beta_tester instance_manager issue_display_mode trusted_api_user mails)
   end
 
 	def create_journal

--- a/lib/redmine_admin_activity/models/user.rb
+++ b/lib/redmine_admin_activity/models/user.rb
@@ -21,7 +21,8 @@ class User < Principal
 
   # Returns the names of attributes that are journalized when updating the user
   def journalized_attribute_names
-    %w(login firstname lastname admin status organization_id sudoer staff beta_tester instance_manager issue_display_mode trusted_api_user mails)
+    excluded_names = User.column_names - %w(login firstname lastname admin status organization_id sudoer staff beta_tester instance_manager issue_display_mode trusted_api_user)
+    names = User.column_names - excluded_names + ["mails"]
   end
 
 	def create_journal

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -64,5 +64,33 @@ if Redmine::Plugin.installed?(:redmine_organizations)
       end
 
     end
+
+    describe "patch Update" do
+      it "logs change on JournalSetting when we update a organization" do
+        org = Organization.last
+        expect do
+          patch :update, :params => {
+            :id => org.id,
+            :organization => {
+              :name => "new_name",
+              :description => "new_des",
+              :parent_id => Organization.find(2).id,
+              :mail => "test@test.com",
+              :direction => true,
+            }
+          }
+        end.to change { JournalSetting.count }.by(1)
+
+        expect(JournalSetting.last.value_changes).to include({ "name" => [org.name, "new_name"] })
+        expect(JournalSetting.last.value_changes).to include({ "description" => [org.description, "new_des"] })
+        expect(JournalSetting.last.value_changes).to include({ "parent_id" => [org.parent.id, Organization.find(2).id] })
+        expect(JournalSetting.last.value_changes).to include({ "direction" => [nil, true] })
+        expect(JournalSetting.last.value_changes).to include({ "mail" => [org.mail, "test@test.com"] })
+        expect(JournalSetting.last).to have_attributes(:journalized_type => "Organization")
+        expect(JournalSetting.last).to have_attributes(:journalized_id => org.id)
+        expect(JournalSetting.last).to have_attributes(:journalized_entry_type => "update")
+
+      end
+    end
   end
 end

--- a/spec/helpers/journal_settings_helper_spec.rb
+++ b/spec/helpers/journal_settings_helper_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe "JournalSettingsHelper" do
   include ApplicationHelper
   include PluginAdminActivity::JournalSettingsHelper
+  include PluginAdminActivity::IssuesHelper
 
   fixtures :projects, :users
 
@@ -271,5 +272,91 @@ describe "JournalSettingsHelper" do
         expect(organization_update_text(journal)).to eq "Organization <i>#{org.fullname}</i> has been deleted."
       end
     end
+
+    describe "organization updating" do
+      it "should generate the right translated sentence, when changing its parent" do
+        org = Organization.last
+
+        journal = JournalSetting.new(:user_id => User.current.id,
+                                       :value_changes => {
+                                          "name" => [org.name, "new_name"],
+                                          "description" => [org.description, "new_des"],
+                                          "parent_id" => [org.parent.id, 2],
+                                          "direction" => [false, true],
+                                          "mail" => [org.mail, "new_mail@test.com"],
+                                        },
+                                       :journalized => org,
+                                       :journalized_entry_type => "update")
+
+        expect(organization_update_text(journal)).to include(
+          "Organization <i><a href=\"/organizations/#{org.id}\">#{org.fullname}</a></i> has been updated.")
+
+        expect(organization_update_text(journal)).to include(
+          "#{l("field_name")} changed from #{org.name} to new_name")
+
+        expect(organization_update_text(journal)).to include(
+          "#{l("field_description")} changed from #{org.description} to new_des")
+
+        expect(organization_update_text(journal)).to include(
+          l(:text_journal_belongs_to_changed, :class_name =>"Organization",
+            :new => Organization.find(2).to_s,
+            :old => org.parent.to_s))
+
+        # Here there is a boolean field, it will test both methods show_boolean_details and val_to_bool
+        expect(organization_update_text(journal)).to include(
+          "#{l("field_direction")} changed from #{l("label_0")} to #{l("label_1")}")
+
+        expect(organization_update_text(journal)).to include(
+          "#{l("field_mail")} changed from #{org.mail} to new_mail@test.com")
+      end
+
+      # test show_belongs_to_details When the absence of the new value
+      it "should generate the right translated sentence, when removing its parent" do
+        org = Organization.last
+
+        journal = JournalSetting.new(:user_id => User.current.id,
+                                       :value_changes => {
+                                          "parent_id" => [org.parent.id, nil],
+                                        },
+                                       :journalized => org,
+                                       :journalized_entry_type => "update")
+
+        expect(organization_update_text(journal)).to include(
+          "Organization <i><a href=\"/organizations/#{org.id}\">#{org.fullname}</a></i> has been updated.")
+
+        expect(organization_update_text(journal)).to include(
+          l(:text_journal_belongs_to_deleted, :class_name =>"Organization",
+            :old => org.parent.to_s))
+      end
+
+      # test show_belongs_to_details When the absence of the old value
+      it "should generate the right translated sentence, when adding the parent" do
+        org = Organization.create(
+                  :name => 'org_name',
+                  :direction => true,
+                  :description => 'org_des',
+                  :name_with_parents => 'org_name',
+                  :parent_id => nil,)
+
+        journal = JournalSetting.new(:user_id => User.current.id,
+                                       :value_changes => {
+                                          "parent_id" => [nil, Organization.first.id],
+                                          "direction" => [true, false],
+                                        },
+                                       :journalized => org,
+                                       :journalized_entry_type => "update")
+
+        expect(organization_update_text(journal)).to include(
+          "Organization <i><a href=\"/organizations/#{org.id}\">#{org.fullname}</a></i> has been updated.")
+
+        expect(organization_update_text(journal)).to include(
+          "#{l("field_direction")} changed from #{l("label_1")} to #{l("label_0")}")
+
+        expect(organization_update_text(journal)).to include(
+          l(:text_journal_belongs_to_added, :class_name =>"Organization",
+            :new => Organization.first.to_s))
+      end
+    end
+
   end
 end


### PR DESCRIPTION
- Tracer les modifications d'orgainsation
- Modifier les méthodes show_belongs_to_details +  show_associations_details pour qu'elles soient plus génériques 
- Ajout le test
- Générer journalized_attribute_names (model de User)en manière dynamique selon les plugins installés(car le test de preprod ne passe pas)
![image](https://user-images.githubusercontent.com/75627140/159018721-3e1ad95f-e74c-42be-8b85-f6aa95a0b645.png)
