### PR TITLE
Pagination des pages d'historique

### DIFF
--- a/app/helpers/journal_settings_helper.rb
+++ b/app/helpers/journal_settings_helper.rb
@@ -2,15 +2,32 @@ module JournalSettingsHelper
 
   include ApplicationHelper
 
-  def prepare_journal_for_history(journals)
+  # def prepare_journal_for_history(journals)
+  #   journals = journals.includes(:user, :details).
+  #     references(:user, :details).
+  #     reorder(:created_on, :id).to_a
+  #   journals.each_with_index { |j, i| j.indice = i + 1 }
+  #   Journal.preload_journals_details_custom_fields(journals)
+  #   journals.select! { |journal| journal.notes? || journal.visible_details.any? }
+  #   journals.reverse! # Last changes first
+  # end
+  
+  def get_journal_for_history(journals)
     journals = journals.includes(:user, :details).
-      references(:user, :details).
-      reorder(:created_on, :id).to_a
-    journals.each_with_index { |j, i| j.indice = i + 1 }
-    Journal.preload_journals_details_custom_fields(journals)
-    journals.select! { |journal| journal.notes? || journal.visible_details.any? }
-    journals.reverse! # Last changes first
+      reorder(created_on: :desc).
+      references(:user, :details)
+    Journal.preload_journals_details_custom_fields(journals)  
   end
+
+  def add_index_to_journal_for_history(journals)
+    per_page = @journal_pages.per_page.to_i
+    page = @journal_pages.page.to_i
+    position = @journal_count.to_i - (per_page * (page - 1))
+    journals.each do |journal|
+      journal.indice = position
+      position -=1
+    end
+  end  
 
   def settings_update_text(name, changes)
     field_name = l("setting_#{name}")

--- a/app/helpers/journal_settings_helper.rb
+++ b/app/helpers/journal_settings_helper.rb
@@ -1,17 +1,7 @@
 module JournalSettingsHelper
 
   include ApplicationHelper
-
-  # def prepare_journal_for_history(journals)
-  #   journals = journals.includes(:user, :details).
-  #     references(:user, :details).
-  #     reorder(:created_on, :id).to_a
-  #   journals.each_with_index { |j, i| j.indice = i + 1 }
-  #   Journal.preload_journals_details_custom_fields(journals)
-  #   journals.select! { |journal| journal.notes? || journal.visible_details.any? }
-  #   journals.reverse! # Last changes first
-  # end
-  
+ 
   def get_journal_for_history(journals)
     journals = journals.includes(:user, :details).
       reorder(created_on: :desc).

--- a/app/views/projects/_admin_activity.html.erb
+++ b/app/views/projects/_admin_activity.html.erb
@@ -3,7 +3,7 @@
     <h3><%=l(:label_history)%></h3>
     <%= render :partial => 'history', :locals => { :journals => @journals } %>
     <span class="pagination"><%=  pagination_links_full(@journal_pages, @journal_count, 
-                                                        :per_page_links => false) do |text, parameters, options|
+                                                        :per_page_links => true) do |text, parameters, options|
                                                           link_to text, request.path + "?" + parameters.to_query
                                                         end %>
     </span>

--- a/app/views/projects/_admin_activity.html.erb
+++ b/app/views/projects/_admin_activity.html.erb
@@ -1,8 +1,8 @@
-<% @journals = prepare_journal_for_history(@project.journals) %>
-
-<% if @journals.present? %>
+<% if @journals.any? %>
   <div id="history">
     <h3><%=l(:label_history)%></h3>
     <%= render :partial => 'history', :locals => { :journals => @journals } %>
+    <span class="pagination"><%= pagination_links_full @journal_pages, @journal_count %></span>
   </div>
 <% end %>
+

--- a/app/views/projects/_admin_activity.html.erb
+++ b/app/views/projects/_admin_activity.html.erb
@@ -2,7 +2,10 @@
   <div id="history">
     <h3><%=l(:label_history)%></h3>
     <%= render :partial => 'history', :locals => { :journals => @journals } %>
-    <span class="pagination"><%= pagination_links_full @journal_pages, @journal_count %></span>
+    <span class="pagination"><%=  pagination_links_full(@journal_pages, @journal_count, 
+                                                        :per_page_links => false) do |text, parameters, options|
+                                                          link_to text, request.path + "?" + parameters.to_query
+                                                        end %>
+    </span>
   </div>
 <% end %>
-

--- a/app/views/settings/_admin_activity.html.erb
+++ b/app/views/settings/_admin_activity.html.erb
@@ -2,6 +2,15 @@
   <div id="history">
     <h3><%=l(:label_history)%></h3>
     <%= render :partial => 'history', :locals => { :journals => @journals } %>
-    <span class="pagination"><%= pagination_links_full @journal_pages, @journal_count %></span>
+    <span class="pagination"><%=  pagination_links_full(@journal_pages, @journal_count, 
+                                                        :per_page_links => false) do |text, parameters, options|
+                                                          unless parameters.key?(:tab)
+                                                            parameters[:tab] = tab[:name]
+                                                          end
+                                                          link_to text, request.path + "?" + parameters.to_query
+                                                        end %>
+    </span>
+
+
   </div>
 <% end %>

--- a/app/views/settings/_admin_activity.html.erb
+++ b/app/views/settings/_admin_activity.html.erb
@@ -3,7 +3,7 @@
     <h3><%=l(:label_history)%></h3>
     <%= render :partial => 'history', :locals => { :journals => @journals } %>
     <span class="pagination"><%=  pagination_links_full(@journal_pages, @journal_count, 
-                                                        :per_page_links => false) do |text, parameters, options|
+                                                        :per_page_links => true) do |text, parameters, options|
                                                           unless parameters.key?(:tab)
                                                             parameters[:tab] = tab[:name]
                                                           end

--- a/app/views/settings/_admin_activity.html.erb
+++ b/app/views/settings/_admin_activity.html.erb
@@ -1,12 +1,7 @@
-<%
-  @journals = JournalSetting.includes(:user).order(:created_on => :asc)
-                                            .each_with_index {|j, i| j.indice = i+1}
-                                            .reverse
-%>
-
 <% if @journals.present? %>
   <div id="history">
     <h3><%=l(:label_history)%></h3>
     <%= render :partial => 'history', :locals => { :journals => @journals } %>
+    <span class="pagination"><%= pagination_links_full @journal_pages, @journal_count %></span>
   </div>
 <% end %>

--- a/app/views/users/history.html.erb
+++ b/app/views/users/history.html.erb
@@ -6,8 +6,7 @@
   page_title.insert(page_title.rindex(' ') + 1, avatar(@user).to_s)
 %>
 
-<% @journals = prepare_journal_for_history(@user.journals) %>
-
-<% if @journals.present? %>
+<% if @journals.any? %>
   <%= render :partial => 'projects/history', :locals => { :journals => @journals } %>
+  <span class="pagination"><%= pagination_links_full @journal_pages, @journal_count %></span> 
 <% end %>

--- a/lib/redmine_admin_activity/controllers/projects_controller.rb
+++ b/lib/redmine_admin_activity/controllers/projects_controller.rb
@@ -12,6 +12,12 @@ class ProjectsController
   after_action :journalized_projects_closing, :only => [:close]
   after_action :journalized_projects_archivation, :only => [:archive]
   after_action :journalized_projects_reopen, :only => [:reopen]
+  before_action :get_projects_journals_for_pagination, :only => [:settings]
+
+  alias_method :settings, :settings
+
+  helper :journal_settings
+  include JournalSettingsHelper
 
   def init_journal
     @project.init_journal(User.current)
@@ -235,6 +241,14 @@ class ProjectsController
                                          when "archive", "destroy"
                                            @project.self_and_descendants.to_a
                                          end
+  end
+
+  def get_projects_journals_for_pagination
+    @scope = get_journal_for_history(@project.journals)
+    @journal_count = @scope.count
+    @journal_pages = Paginator.new @journal_count, per_page_option, params['page'] 
+    @journals = @scope.limit(@journal_pages.per_page).offset(@journal_pages.offset).to_a   
+    @journals = add_index_to_journal_for_history(@journals)
   end
 
 end

--- a/lib/redmine_admin_activity/controllers/settings_controller.rb
+++ b/lib/redmine_admin_activity/controllers/settings_controller.rb
@@ -3,6 +3,10 @@ require_dependency 'settings_controller'
 class SettingsController
   before_action :intialize_settings_was, :only => [:edit]
   after_action :track_settings_was_changes, :only => [:edit]
+  before_action :get_settings_journals_for_pagination, :only => [:index]
+
+  helper :journal_settings
+  include JournalSettingsHelper
 
   private
 
@@ -30,4 +34,15 @@ class SettingsController
       :value_changes => changes
     )
   end
+
+  def get_settings_journals_for_pagination
+    @scope = JournalSetting.includes(:user).
+    reorder(created_on: :desc).
+    references(:user)
+    @journal_count = @scope.count
+    @journal_pages = Paginator.new @journal_count, per_page_option, params['page'] 
+    @journals = @scope.limit(@journal_pages.per_page).offset(@journal_pages.offset).to_a   
+    @journals = add_index_to_journal_for_history(@journals)
+  end
+
 end

--- a/lib/redmine_admin_activity/controllers/users_controller.rb
+++ b/lib/redmine_admin_activity/controllers/users_controller.rb
@@ -12,7 +12,16 @@ class UsersController
   before_action lambda { find_user(false) }, :only => :history
 
   def history
-
+    respond_to do |format|
+      format.html do
+        @scope = get_journal_for_history(@user.journals)
+        @journal_count = @scope.count
+        @journal_pages = Paginator.new @journal_count, per_page_option, params['page'] 
+        @journals = @scope.limit(@journal_pages.per_page).offset(@journal_pages.offset).to_a   
+        @journals = add_index_to_journal_for_history(@journals)
+      end
+      
+    end
   end
 
   def journalized_users_creation

--- a/lib/redmine_admin_activity/controllers/users_controller.rb
+++ b/lib/redmine_admin_activity/controllers/users_controller.rb
@@ -12,16 +12,11 @@ class UsersController
   before_action lambda { find_user(false) }, :only => :history
 
   def history
-    respond_to do |format|
-      format.html do
-        @scope = get_journal_for_history(@user.journals)
-        @journal_count = @scope.count
-        @journal_pages = Paginator.new @journal_count, per_page_option, params['page'] 
-        @journals = @scope.limit(@journal_pages.per_page).offset(@journal_pages.offset).to_a   
-        @journals = add_index_to_journal_for_history(@journals)
-      end
-      
-    end
+    @scope = get_journal_for_history(@user.journals)
+    @journal_count = @scope.count
+    @journal_pages = Paginator.new @journal_count, per_page_option, params['page'] 
+    @journals = @scope.limit(@journal_pages.per_page).offset(@journal_pages.offset).to_a   
+    @journals = add_index_to_journal_for_history(@journals)
   end
 
   def journalized_users_creation

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -253,11 +253,9 @@ describe ProjectsController, type: :controller do
 
     it "check the number of elements by page" do
       # Generating 5 Journals Settings
-      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 1' }}
-      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 3' }}
-      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 2' }}
-      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 4' }}
-      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 5' }}
+      5.times do |index|
+        patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => "Test changed name #{index}" }}
+      end
 
       # Get all journals of the first page
       get :settings, :params => { :id => Project.find(1).id, :tab => "admin_activity", page: 1}

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -253,9 +253,9 @@ describe ProjectsController, type: :controller do
 
     it "check the number of elements by page" do
       # Generating 5 Journals Settings
-      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name' }}
-      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 2' }}
+      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 1' }}
       patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 3' }}
+      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 2' }}
       patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 4' }}
       patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 5' }}
 
@@ -270,10 +270,7 @@ describe ProjectsController, type: :controller do
       # Tests
       expect(first_page.count).to eq(3)
       expect(second_page.count).to eq(2)
-      expect(first_page.first.id).to be > second_page.first.id
-
-      
+      expect(first_page.first.id).to be > second_page.first.id      
     end
   end
-
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -245,4 +245,35 @@ describe ProjectsController, type: :controller do
       end
     end
   end
+
+  describe "Pagination of project history" do
+    before do
+      session[:per_page] = 3
+    end
+
+    it "check the number of elements by page" do
+      # Generating 5 Journals Settings
+      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name' }}
+      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 2' }}
+      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 3' }}
+      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 4' }}
+      patch :update, :params => { :id => "ecookbook" , :project => { issue_template_ids: [], :name => 'Test changed name 5' }}
+
+      # Get all journals of the first page
+      get :settings, :params => { :id => Project.find(1).id, :tab => "admin_activity", page: 1}
+      first_page = assigns(:journals)
+
+      # Get all journals of the second page
+      get :settings, :params => { :id => Project.find(1).id, :tab => "admin_activity", page: 2}
+      second_page = assigns(:journals)
+
+      # Tests
+      expect(first_page.count).to eq(3)
+      expect(second_page.count).to eq(2)
+      expect(first_page.first.id).to be > second_page.first.id
+
+      
+    end
+  end
+
 end

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -24,4 +24,33 @@ describe SettingsController, type: :controller do
       expect(JournalSetting.last).to have_attributes(:value_changes => { "app_title" => ["Redmine", "Redmine test"] })
     end
   end
+
+  describe "Pagination of user history" do
+    before do
+      session[:per_page] = 3
+    end
+
+    it "check the number of elements by page" do
+      Setting[:app_title] = "Redmine"
+      post :edit, params: { "settings" => { "app_title" => "Redmine test 1" } }
+      post :edit, params: { "settings" => { "app_title" => "Redmine test 2" } }
+      post :edit, params: { "settings" => { "app_title" => "Redmine test 3" } }
+      post :edit, params: { "settings" => { "app_title" => "Redmine test 4" } }
+      post :edit, params: { "settings" => { "app_title" => "Redmine test 5" } }
+      
+      # Get all journals of the first page
+      get :index, :params => { :tab => "admin_activity", page: 1}
+      first_page = assigns(:journals)
+
+      # Get all journals of the second page
+      get :index, :params => { :tab => "admin_activity", page: 2}
+      second_page = assigns(:journals)
+
+      # Tests
+      expect(first_page.count).to eq(3)
+      expect(second_page.count).to eq(2)
+      expect(first_page.first.id).to be > second_page.first.id      
+    end
+  end
+
 end

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -32,12 +32,10 @@ describe SettingsController, type: :controller do
 
     it "check the number of elements by page" do
       Setting[:app_title] = "Redmine"
-      post :edit, params: { "settings" => { "app_title" => "Redmine test 1" } }
-      post :edit, params: { "settings" => { "app_title" => "Redmine test 2" } }
-      post :edit, params: { "settings" => { "app_title" => "Redmine test 3" } }
-      post :edit, params: { "settings" => { "app_title" => "Redmine test 4" } }
-      post :edit, params: { "settings" => { "app_title" => "Redmine test 5" } }
-      
+      5.times do |index|
+        post :edit, params: { "settings" => { "app_title" => "Redmine test #{index}" } }
+      end
+    
       # Get all journals of the first page
       get :index, :params => { :tab => "admin_activity", page: 1}
       first_page = assigns(:journals)


### PR DESCRIPTION
La paginatation des pages d'historique a été réalisée pour : les utilisateurs, les projets et la configuration.

Des tests ont été ajoutés pour vérifier que le nombre d'éléments par page est correct ainsi que leur ordre.